### PR TITLE
Fix Postgres create database command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Execute the following script, changing values like password and username (you wi
 
 ~~~
 CREATE USER librephotos WITH PASSWORD 'password';
-CREATE DATABASE "librephotos" WITH OWNER "librephotos" WITH TEMPLATE = template0 ENCODING = "UTF8";
+CREATE DATABASE "librephotos" WITH OWNER "librephotos" TEMPLATE = template0 ENCODING = "UTF8";
 GRANT ALL privileges ON DATABASE librephotos TO librephotos;
 quit
 ~~~


### PR DESCRIPTION
Using a template should not begin with 'WITH'.
I removed it from the command.