### PR TITLE
Resolved some issues

### DIFF
--- a/Cleanup.md
+++ b/Cleanup.md
@@ -1,6 +1,6 @@
 # How to cleanup (Ubuntu)
 
-# Almost all in one place  
+## Almost all in one place  
 This removes files from system, drps database. Installed from repositories or compiled software must remove manually.
 ``` bash
 su - postgres << EOF

--- a/Cleanup.md
+++ b/Cleanup.md
@@ -1,3 +1,7 @@
+# How to cleanup (Ubuntu)
+
+Some notes what to clean up.
+
 # Compiled software uninstallation  
 Go to the source folder, and run  
 ```bash
@@ -6,6 +10,8 @@ make uninstall
 
 Or dirty way:
 Delete all releated files in the `/usr/local/include`, also check in the `/usr/local/....` documentation files, etc.  
+
+Sometimes Librephotos not starting after installation. If on the systems left some old compiled packages, will result version mismatch, and gunicorn (backend) will not start. Uninstall compiled (local) software and try again.
 
 # Cleanup database by droping it and user  
 ``` bash
@@ -28,7 +34,7 @@ systemctl disable librephotos-backend
 systemctl disable librephotos-worker.service
 systemctl disable librephotos-image-similarity.service
 systemctl disable librephotos-backend
-``` 
+```
 And removing service files:
 ```bash
 rm -r /etc/systemd/system/librephotos-*

--- a/Cleanup.md
+++ b/Cleanup.md
@@ -1,8 +1,32 @@
 # How to cleanup (Ubuntu)
 
-Some notes what to clean up.
+# Almost all in one place  
+This removes files from system, drps database. Installed from repositories or compiled software must remove manually.
+``` bash
+su - postgres << EOF
+psql -c 'DROP DATABASE IF EXISTS librephotos;'
+psql -c 'DROP USER IF EXISTS librephotos;'
+exit
+EOF
+systemctl disable librephotos-backend
+systemctl disable librephotos-worker.service
+systemctl disable librephotos-image-similarity.service
+systemctl disable librephotos-backend
+rm -r /etc/systemd/system/librephotos-*
+userdel -fr librephotos
+rm -r $BASE_DATA/data_models/
+rm -r $BASE_DATA/protected_media
+rm -r /etc/librephotos/
+rm -r /var/log/librephotos
+unlink /usr/sbin/librephotos-cli
+rm /etc/nginx/sites-enabled/librephotos
+rm /etc/nginx/sites-available/librephotos
+service nginx reload
+```
 
-# Compiled software uninstallation  
+# Some explanation what to clean up.
+
+## Compiled software uninstallation  
 Go to the source folder, and run  
 ```bash
 make uninstall
@@ -13,7 +37,7 @@ Delete all releated files in the `/usr/local/include`, also check in the `/usr/l
 
 Sometimes Librephotos not starting after installation. If on the systems left some old compiled packages, will result version mismatch, and gunicorn (backend) will not start. Uninstall compiled (local) software and try again.
 
-# Cleanup database by droping it and user  
+## Cleanup database by droping it and user  
 ``` bash
 su - postgres << EOF
 psql -c 'DROP DATABASE IF EXISTS librephotos;'
@@ -22,13 +46,13 @@ exit
 EOF
 ```
 
-# Delete system user and remove HOME
+## Delete system user and remove HOME
 Default home `/usr/lib/librephotos`. This action removes frontend, backend and all other files in the librephotos home.
 ```bash
 userdel -fr librephotos
 ```  
 
-# Disabling systemd services  
+## Disabling systemd services  
 ```bash
 systemctl disable librephotos-backend
 systemctl disable librephotos-worker.service
@@ -40,33 +64,33 @@ And removing service files:
 rm -r /etc/systemd/system/librephotos-*
 ```
 
-# Cleanup folders  
-## logs  
+## Cleanup folders  
+### logs  
 ```bash
 rm -r /var/log/librephotos
 ```
-## thumbails, some software like places, clips-embeddings, etc). Photo not touching in the $BASE_DATA/data
+### thumbails, some software like places, clips-embeddings, etc). Photo not touching in the $BASE_DATA/data
 ```bash
 rm -r $BASE_DATA/data_models/
 rm -r $BASE_DATA/protected_media
 rm -r /etc/librephotos/
 ```  
 
-## unlinking    
+### unlinking    
 ```bash
 unlink /usr/sbin/librephotos-cli
 ```
-## nginx  
-### virtual host. Only if nginx were before librephotos installation  
+### nginx  
+#### virtual host. Only if nginx were before librephotos installation  
 ```bash
 rm /etc/nginx/sites-enabled/librephotos
 rm /etc/nginx/sites-available/librephotos
 service nginx reload
 ```
-### if nginx installed by the script  
+#### if nginx installed by the script  
 ```bash
 systemctl stop nginx
 apt remove --purge nginx
 ```
-## Other software.  
+### Other software.  
 If software are only for librephotos, can remove redis-server, postgresql. All other not recommend - maybe it is used to other purposes.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ nano install-librephotos.sh
 ./install-librephotos.sh
 ~~~
 Admin password will store in /tmp/ADMIN_PASS.
-After changing the photos directory, must edit one of the `/etc/nginx/nginx.conf` or `/etc/nginx/sites-available/librephotos`. There are three places `alias /var/lib/librephotos.
+After changing the photos directory, must edit one of the `/etc/nginx/nginx.conf` or `/etc/nginx/sites-available/librephotos`. There are four places `alias /var/lib/librephotos.
 
 No cheking Apache or any other web server exsistense on system. Please adopt script. Easies way to remove all lines, releated with nginx, and create virtual host in Apache.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Currently, these are in a early stage; some bugs may exist. If you find any, ple
 ## Contribution
 These are community maintained scripts to allow for a local install. If you have implemented an improvement, please consider opening up a pull request.
 
+## Notes
+
+Script is not adopted to remote postgresql server.
+
 ## Compatibility
 - Ubuntu 20.04.x LTS (server)
 - Ubuntu 21.04 (desktop)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently, these are in a early stage; some bugs may exist. If you find any, ple
 These are community maintained scripts to allow for a local install. If you have implemented an improvement, please consider opening up a pull request.
 
 ## Compatibility
-- Ubuntu 20.04.2 LTS (server)
+- Ubuntu 20.04.x LTS (server)
 - Ubuntu 21.04 (desktop)
 
 ## Pre-Installation
@@ -23,7 +23,7 @@ sudo apt install git -y
 Execute the following commands as root. Edit the begining of the script, and execute. This will create systemuser 'librephotos', creates directories, installs necessary software, creates database and automaGically writes some variables to librephotos-backend.env file.
 ~~~
 sudo su
-cd /tmp/
+cd
 git clone https://github.com/Seneliux/librephotos-linux.git
 cd librephotos-linux
 nano install-librephotos.sh
@@ -31,10 +31,10 @@ nano install-librephotos.sh
 ~~~
 ./install-librephotos.sh
 ~~~
-Admin password will store in /tmp/ADMIN_PASS. 
+Admin password will store in /tmp/ADMIN_PASS.
 After changing the photos directory, must edit one of the `/etc/nginx/nginx.conf` or `/etc/nginx/sites-available/librephotos`. There are three places `alias /var/lib/librephotos.
 
-No cheking Apache or any other web server exsistense on system. Please adopt script. Easies way to remove all lines, releated with nginx, and create virtual host in Apache. 
+No cheking Apache or any other web server exsistense on system. Please adopt script. Easies way to remove all lines, releated with nginx, and create virtual host in Apache.
 
 ~~~
 nano /etc/librephotos/librephotos-backend.env
@@ -67,4 +67,4 @@ librephotos-cli clear_cache
 ~~~
 ## TO DO
 - [ ] remote / local user permissions to write to the photos folder (samba, webdav, nextcloud, nfs)
-- [ ] android sync (client, synthing, webdav) 
+- [ ] android sync (client, synthing, webdav)

--- a/README.md
+++ b/README.md
@@ -32,12 +32,9 @@ nano install-librephotos.sh
 ./install-librephotos.sh
 ~~~
 Admin password will store in /tmp/ADMIN_PASS. 
-After changing the photos directory, must edit one of the `/etc/nginx/nginx.conf` or `/etc/nginx/sites-available/librephotos`. There are three places `alias /var/lib/librephotos`.
+After changing the photos directory, must edit one of the `/etc/nginx/nginx.conf` or `/etc/nginx/sites-available/librephotos`. There are three places `alias /var/lib/librephotos.
 
-Edit `/etc/librephotos/librephotos-backend.env` to store configuration variables, such as:
-
- - redis information
-In case you configured it with a password or are using a special path.
+No cheking Apache or any other web server exsistense on system. Please adopt script. Easies way to remove all lines, releated with nginx, and create virtual host in Apache. 
 
 ~~~
 nano /etc/librephotos/librephotos-backend.env

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ These are community maintained scripts to allow for a local install. If you have
 
 ## Notes
 
-Script is not adopted to remote postgresql server.
+Script is not adopted to remote postgresql server.  
+If REDIS present on the system AND connection to it through socket, change socket permissions to 770.  librephotos user will be added to redis group.
 
 ## Compatibility
 - Ubuntu 20.04.x LTS (server)

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -1,18 +1,44 @@
 #!/usr/bin/env bash
 
-######################### HERE EDIT VARIABLES #############################
-# the location of photos. If changed here, also must change in nginx
+######################### HERE EDIT VARIABLES ################################################
+# the location of photos. If changed here, also must change the path in thenginx virtual host.
+# /etc/nginx
 export BASE_DATA=/var/lib/librephotos
 export ADMIN_USERNAME=
 export ADMIN_EMAIL=
 # Not mandatory:
 export MAPBOX_API_KEY=
-export FORWARDED_ALLOW_IPS=
-# If your hardware without AVX and SSE instructions, seach in this file
-# 'dlib' and read instructions :) In most cases this for the old hardware
-######################### END OF EDITABLE SECTION ##########################
+export TIME_ZONE=Europe/Berlin
+# If your hardware without AVX and SSE instructions, seach in this file by keyword
+# 'dlib' and read instructions :) Modern system have these
 
-set -ea
+######## Below change ONLY if you know what are you doing. #####################
+# Front-end’s IPs from which allowed to handle set secure headers. (comma separate).
+# Ref: https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips
+# Ref2: https://github.com/benoitc/gunicorn/issues/1857
+# '*' to disable
+export FORWARDED_ALLOW_IPS=
+
+# Postgresql connection settings
+DB_HOST=localhost
+DB_PORT=5432
+
+# REDIS connection settings. Unnecessary settings comment with TWO SYMBOLS "\#" or delete.
+# set REDIS sock permissions to 770 and restart REDIS. Script adds librephotos to redis group.
+# for sock connection leave uncommented only REDIS_PATH, all other settings comment out.
+REDIS=( \#REDIS_PASS= \#REDIS_DB= REDIS_HOST=localhost REDIS_PORT=6379 \#REDIS_PATH=/run/redis/redis-server.sock )
+
+# If postgresql server is NOT local, after installation remove from these files
+# /etc/systemd/system/librephotos-backend.service
+# /etc/systemd/system/librephotos-worker.service
+# these settings:
+# postgresql.service
+# Requires=postgresql.service
+
+# If CPU supports SSE2, AVX, find in the script FFTW and uncomment configure settings
+######################### END OF EDITABLE SECTION #########################################
+
+set -exa
 # PRE INSTALL
 id -g librephotos > /dev/null || groupadd -r librephotos
 id -u librephotos > /dev/null || useradd --home-dir /usr/lib/librephotos --comment "librephotos user" -g librephotos -mr -s /usr/sbin/nologin librephotos
@@ -20,7 +46,7 @@ id -u librephotos > /dev/null || useradd --home-dir /usr/lib/librephotos --comme
 export BASE_LOGS=/var/log/librephotos
 
 mkdir -p $BASE_LOGS
-mkdir -p $BASE_DATA/data_models/{places365,im2txt}
+mkdir -p $BASE_DATA/data_models/{places365,im2txt,clip-embeddings}
 mkdir -p $BASE_DATA/protected_media/{thumbnails_big,square_thumbnails,square_thumbnails_small,faces}
 mkdir -p $BASE_DATA/data/nextcloud_media
 chown -R librephotos:librephotos $BASE_LOGS
@@ -30,22 +56,34 @@ chown -R librephotos:librephotos $BASE_DATA
 
 REQUIRED_PKG=( wget swig ffmpeg libimage-exiftool-perl libpq-dev postgresql curl libopenblas-dev libmagic1 libboost-all-dev libxrender-dev \
 liblapack-dev git bzip2 cmake build-essential libsm6 libglib2.0-0 libgl1-mesa-glx gfortran gunicorn \
-libheif-dev libssl-dev rustc liblzma-dev python3 python3-pip imagemagick redis )
+libheif-dev libssl-dev rustc liblzma-dev python3 python3-pip imagemagick redis-server )
 for i in "${REQUIRED_PKG[@]}"; do
 [ $(dpkg-query -W -f='${Status}' $i 2>/dev/null | grep -c "ok installed") -eq 0 ] && apt install --no-install-recommends -y $i
 done
 
 # This part compiles libvips. More info https://libvips.github.io/libvips/install.html
 REQUIRED_PKG=( build-essential pkg-config libglib2.0-dev libexpat1-dev libgsf-1-dev liborc-dev libexif-dev libtiff-dev \
-libjpeg-turbo8-dev librsvg2-dev libpng-dev libwebp-dev)
+libjpeg-turbo8-dev librsvg2-dev libpng-dev libwebp-dev )
 for i in "${REQUIRED_PKG[@]}"; do
 [ $(dpkg-query -W -f='${Status}' $i 2>/dev/null | grep -c "ok installed") -eq 0 ] && apt install --no-install-recommends -y $i
-done
-wget https://github.com/libvips/libvips/releases/download/v8.11.2/vips-8.11.2.tar.gz
-tar xf vips-8.11.2.tar.gz
-cd vips-8.11.2
-./configure
-make
+ done
+
+wget http://fftw.org/fftw-3.3.10.tar.gz
+tar xf fftw-3.3.10.tar.gz
+cd fftw-3.3.10
+# FFTW. if CPU support sse2, avx, uncomment these:
+./configure --enable-threads --with-pic #--enable-sse2 --enable-avx
+make -j$(nproc --all)
+make install
+ldconfig
+cd ..
+
+wget https://github.com/libvips/libvips/releases/download/v8.12.1/vips-8.12.1.tar.gz
+tar xf vips-8.12.1.tar.gz
+cd vips-8.12.1
+[ $(dpkg-query -W -f='${Status}' libmagick++-dev 2>/dev/null | grep -c "ok installed") -eq 0 ] && apt install --no-install-recommends -y libmagick++-dev
+./configure --with-magickpackage=ImageMagick
+make -j$(nproc --all)
 make install
 ldconfig
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib' >>  /usr/lib/librephotos/.bashrc
@@ -54,19 +92,20 @@ cd ..
 su - -s $(which bash) librephotos << EOF
 curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/places365.tar.gz | tar -zxC $BASE_DATA/data_models/
 curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/im2txt.tar.gz | tar -zxC $BASE_DATA/data_models/
+curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/clip-embeddings.tar.gz | tar -zxC $BASE_DATA/data_models/
 mkdir -p ~/.cache/torch/hub/checkpoints/
 curl -SL https://download.pytorch.org/models/resnet152-b121ed2d.pth -o ~/.cache/torch/hub/checkpoints/resnet152-b121ed2d.pth
 pip3 install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
 #################################################################################################
-# Here seting up AVX and SSE support.  
+# Here seting up AVX and SSE support.
 # Comment out first line 'pip3 install...' and uncoment second. Must leave only one.
 ##################################################################################################
 pip3 install -v --install-option="--no" --install-option="DLIB_USE_CUDA" dlib
 #pip3 install -v --install-option="--no" --install-option="DLIB_USE_CUDA" --install-option="--no" --install-option="USE_AVX_INSTRUCTIONS" --install-option="--no" --install-option="USE_SSE4_INSTRUCTIONS" dlib
-#This does only support x64 and not ARM. To install for ARM you have to build it from source 
+#This does only support x64 and not ARM. To install for ARM you have to build it from source
 pip3 install faiss-cpu
 pip3 install pyvips
-git clone https://github.com/LibrePhotos/librephotos.git backend
+git clone https://github.com/Seneliux/librephotos.git backend
 cd backend
 pip3 install -r requirements.txt
 EOF
@@ -86,23 +125,29 @@ chmod +x /tmp/database_pass
 
 # POST INSTALL
 
+usermod -aG redis librephotos
 [ -d /usr/lib/librephotos/bin ] || mkdir -p /usr/lib/librephotos/bin
 cp ressources/bin/* /usr/lib/librephotos/bin/
 ln -fs /usr/lib/librephotos/bin/librephotos-cli /usr/sbin/librephotos-cli
 chown -R librephotos:librephotos  /usr/lib/librephotos/bin/
 cp -r ressources/etc/librephotos/ /etc/
 cp ressources/systemd/* /etc/systemd/system/
+
 sed -i "s|DB_PASS=password|DB_PASS=${pass}|g" /etc/librephotos/librephotos-backend.env
 secret_key=$( < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-16};)
 sed -i "s|SECRET_KEY=SecretKeyToBeDefined|SECRET_KEY=${secret_key}|g" /etc/librephotos/librephotos-backend.env
 sed -i "s|BASE_DATA=|BASE_DATA=${BASE_DATA}|g" /etc/librephotos/librephotos-backend.env
 sed -i "s|MAPBOX_API_KEY=|MAPBOX_API_KEY=${MAPBOX_API_KEY}|g" /etc/librephotos/librephotos-backend.env
 sed -i "s|FORWARDED_ALLOW_IPS=|FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS}|g" /etc/librephotos/librephotos-backend.env
+sed -i "s|DB_HOST=|DB_HOST=${DB_HOST}|g" /etc/librephotos/librephotos-backend.env
+sed -i "s|DB_PORT=|DB_PORT=${DB_PORT}|g" /etc/librephotos/librephotos-backend.env
+echo TIME_ZONE=${TIME_ZONE} >> /etc/librephotos/librephotos-backend.env
+for i in "${REDIS[@]}"; do
+  echo $i >> /etc/librephotos/librephotos-backend.env
+done
 rm /tmp/database_pass
 
-systemctl start librephotos-backend
-systemctl start librephotos-worker.service
-systemctl start librephotos-image-similarity.service
+systemctl start librephotos-worker.service && systemctl start librephotos-backend && systemctl start librephotos-image-similarity.service && echo
 systemctl enable librephotos-backend
 systemctl enable librephotos-worker.service
 systemctl enable librephotos-image-similarity.service
@@ -117,7 +162,7 @@ done
 curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - && apt install nodejs -y --no-install-recommends
 npm install -g yarn
 su - -s $(which bash) librephotos << EOF
-git clone https://github.com/LibrePhotos/librephotos-frontend.git frontend
+git clone https://github.com/Seneliux/librephotos-frontend.git frontend
 cd frontend
 npm install
 npm run build
@@ -133,7 +178,7 @@ echo ${ADMIN_PASS} > /tmp/ADMIN_PASS
 
 # NGINX REVERSE PROXY
 
-if [ $(dpkg-query -W -f='${Status}' nginx 2>/dev/null | grep -c "ok installed") -eq 0 ];
+if [ $(dpkg-query -W -f='${Status}' nginx* 2>/dev/null | grep -c "ok installed") -eq 0 ];
   then
     apt install -y nginx
     cp ressources/etc/nginx/nginx.conf /etc/nginx/nginx.conf
@@ -142,6 +187,10 @@ if [ $(dpkg-query -W -f='${Status}' nginx 2>/dev/null | grep -c "ok installed") 
     cp ressources/etc/nginx/librephotos /etc/nginx/sites-available/librephotos
     ln -s /etc/nginx/sites-available/librephotos /etc/nginx/sites-enabled/
 fi
-echo Your ADMIN_PASS stored in /tmp/ADMIN_PASS Memorize it now and delete this file.
-echo ADMIN_PASS=${ADMIN_PASS}
-echo If system has the nginx server before installing librephotos, edit virtual host /etc/nginx/librephotos and restart nginx.
+echo Your ADMIN_PASS is:
+cat /tmp/ADMIN_PASS
+echo "It is stored in /tmp/ADMIN_PASS. Memorize it now and delete this file."
+echo "If system has the nginx server before installing librephotos, edit virtual host /etc/nginx/librephotos and restart nginx."
+echo "Optimal: check other settings in the file /etc/librephotos/librephotos-backend.env"
+echo "After changing BASE_DATA, must edit file /etc/nginx/nginx.conf or /etc/nginx/sites-available/librephotos and change accordinaly"
+echo "alias. There  3 lines"-

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -23,7 +23,8 @@ DB_HOST=localhost
 DB_PORT=5432
 
 # REDIS connection settings. Unnecessary settings comment with TWO SYMBOLS "\#" or delete.
-# set REDIS sock permissions to 770 and restart REDIS. Script adds librephotos to redis group.
+# If connection to REDIS  using sock, set REDIS sock permissions to 770 and restart it.
+# Script adds librephotos to redis group.
 # for sock connection leave uncommented only REDIS_PATH, all other settings comment out.
 REDIS=( \#REDIS_PASS= \#REDIS_DB= REDIS_HOST=localhost REDIS_PORT=6379 \#REDIS_PATH=/run/redis/redis-server.sock )
 
@@ -94,6 +95,7 @@ for i in "${REQUIRED_PKG[@]}"; do
 #cd ..
 
 # Compiling libvips from source. Installed libvips42 from repositories not working.
+if ! which vips; then
 wget https://github.com/libvips/libvips/releases/download/v8.12.1/vips-8.12.1.tar.gz
 tar xf vips-8.12.1.tar.gz
 cd vips-8.12.1
@@ -104,6 +106,10 @@ make install
 ldconfig
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib' >>  /usr/lib/librephotos/.bashrc
 cd ..
+else
+echo "VIPS allready found on the system"
+echo "Sometimes older vips can cause problems."
+read -t 5 -p "If librephotos-backend not starting, try to uninstall vips and recompile again"
 
 su - -s $(which bash) librephotos << EOF
 curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/places365.tar.gz | tar -zxC $BASE_DATA/data_models/

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -40,7 +40,7 @@ REDIS=( \#REDIS_PASS= \#REDIS_DB= REDIS_HOST=localhost REDIS_PORT=6379 \#REDIS_P
 
 set -exa
 # PRE INSTALL
-# old user, if exist, removing and recreating new librephotos user
+# if exist, removes old user
 check_user=$(awk -F: -v user=librephotos '$1 == user {print $1}' /etc/passwd)
 [[ $check_user ]] && userdel -rf librephotos
 [[ -d /usr/lib/librephotos ]] && rm -rf /usr/lib/librephotos
@@ -110,6 +110,7 @@ else
 echo "VIPS allready found on the system"
 echo "Sometimes older vips can cause problems."
 read -t 5 -p "If librephotos-backend not starting, try to uninstall vips and recompile again"
+fi
 
 su - -s $(which bash) librephotos << EOF
 curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/places365.tar.gz | tar -zxC $BASE_DATA/data_models/

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -39,6 +39,10 @@ REDIS=( \#REDIS_PASS= \#REDIS_DB= REDIS_HOST=localhost REDIS_PORT=6379 \#REDIS_P
 
 set -exa
 # PRE INSTALL
+# old user, if exist, removing and recreating new librephotos user
+check_user=$(awk -F: -v user=librephotos '$1 == user {print $1}' /etc/passwd)
+[[ $check_user ]] && userdel -rf librephotos
+[[ -d /usr/lib/librephotos ]] && rm -rf /usr/lib/librephotos
 id -g librephotos > /dev/null || groupadd -r librephotos
 id -u librephotos > /dev/null || useradd --home-dir /usr/lib/librephotos --comment "librephotos user" -g librephotos -mr -s /usr/sbin/nologin librephotos
 

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -63,22 +63,32 @@ done
 
 # This part compiles libvips. More info https://libvips.github.io/libvips/install.html
 REQUIRED_PKG=( build-essential pkg-config libglib2.0-dev libexpat1-dev libgsf-1-dev liborc-dev libexif-dev libtiff-dev \
-libjpeg-turbo8-dev librsvg2-dev libpng-dev libwebp-dev )
+ librsvg2-dev libpng-dev libwebp-dev )
 for i in "${REQUIRED_PKG[@]}"; do
 [ $(dpkg-query -W -f='${Status}' $i 2>/dev/null | grep -c "ok installed") -eq 0 ] && apt install --no-install-recommends -y $i
  done
 
-#Optimal. FFTW library.
-wget http://fftw.org/fftw-3.3.10.tar.gz
-tar xf fftw-3.3.10.tar.gz
-cd fftw-3.3.10
+# Some packages differs in Ubuntu and Debian. Here script checks distro and installs correct packages
+distro=$(lsb_release -i | awk '{print($3)}')
+# here Ubuntu packages
+[[ $distro == Ubuntu ]] && REQUIRED_PKG=( libjpeg-turbo8-dev )
+# here Debian packages
+[[ $distro == Debian ]] && REQUIRED_PKG=( libjpeg62-turbo-dev )
+for i in "${REQUIRED_PKG[@]}"; do
+[ $(dpkg-query -W -f='${Status}' $i 2>/dev/null | grep -c "ok installed") -eq 0 ] && apt install --no-install-recommends -y $i
+ done
+
+#Optimal. FFTW library. Fourier Transform can be used in the image edtion. Filters, effects, etc. Librephotos have not (yet) these features.
+#wget http://fftw.org/fftw-3.3.10.tar.gz
+#tar xf fftw-3.3.10.tar.gz
+#cd fftw-3.3.10
 # FFTW. if CPU support sse2, avx, uncomment below.
 # More info about optimization: http://fftw.org/fftw3_doc/Installation-on-Unix.html
-./configure --enable-threads --with-pic #--enable-sse2 --enable-avx
-make -j$(nproc --all)
-make install
-ldconfig
-cd ..
+#./configure --enable-threads --with-pic #--enable-sse2 --enable-avx
+#make -j$(nproc --all)
+#make install
+#ldconfig
+#cd ..
 
 # Compiling libvips from source. Installed libvips42 from repositories not working.
 wget https://github.com/libvips/libvips/releases/download/v8.12.1/vips-8.12.1.tar.gz

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -71,7 +71,8 @@ for i in "${REQUIRED_PKG[@]}"; do
 wget http://fftw.org/fftw-3.3.10.tar.gz
 tar xf fftw-3.3.10.tar.gz
 cd fftw-3.3.10
-# FFTW. if CPU support sse2, avx, uncomment these:
+# FFTW. if CPU support sse2, avx, uncomment below.
+# More info about optimization: http://fftw.org/fftw3_doc/Installation-on-Unix.html
 ./configure --enable-threads --with-pic #--enable-sse2 --enable-avx
 make -j$(nproc --all)
 make install

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -68,6 +68,7 @@ for i in "${REQUIRED_PKG[@]}"; do
 [ $(dpkg-query -W -f='${Status}' $i 2>/dev/null | grep -c "ok installed") -eq 0 ] && apt install --no-install-recommends -y $i
  done
 
+#Optimal. FFTW library.
 wget http://fftw.org/fftw-3.3.10.tar.gz
 tar xf fftw-3.3.10.tar.gz
 cd fftw-3.3.10
@@ -79,6 +80,7 @@ make install
 ldconfig
 cd ..
 
+# Compiling libvips from source. Installed libvips42 from repositories not working.
 wget https://github.com/libvips/libvips/releases/download/v8.12.1/vips-8.12.1.tar.gz
 tar xf vips-8.12.1.tar.gz
 cd vips-8.12.1

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -8,7 +8,6 @@ export ADMIN_USERNAME=
 export ADMIN_EMAIL=
 # Not mandatory:
 export MAPBOX_API_KEY=
-export TIME_ZONE=Europe/Berlin
 # If your hardware without AVX and SSE instructions, seach in this file by keyword
 # 'dlib' and read instructions :) Modern system have these
 
@@ -154,7 +153,6 @@ sed -i "s|MAPBOX_API_KEY=|MAPBOX_API_KEY=${MAPBOX_API_KEY}|g" /etc/librephotos/l
 sed -i "s|FORWARDED_ALLOW_IPS=|FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS}|g" /etc/librephotos/librephotos-backend.env
 sed -i "s|DB_HOST=|DB_HOST=${DB_HOST}|g" /etc/librephotos/librephotos-backend.env
 sed -i "s|DB_PORT=|DB_PORT=${DB_PORT}|g" /etc/librephotos/librephotos-backend.env
-echo TIME_ZONE=${TIME_ZONE} >> /etc/librephotos/librephotos-backend.env
 for i in "${REDIS[@]}"; do
   echo $i >> /etc/librephotos/librephotos-backend.env
 done

--- a/install-librephotos.sh
+++ b/install-librephotos.sh
@@ -135,6 +135,8 @@ EOF
 
 # CREATING DATABASE
 su - postgres << EOF
+psql -c 'DROP DATABASE IF EXISTS librephotos;'
+psql -c 'DROP USER IF EXISTS librephotos;'
 psql -c 'CREATE USER librephotos;'
 psql -c 'CREATE DATABASE "librephotos" WITH OWNER "librephotos" TEMPLATE = template0 ENCODING = "UTF8";'
 psql -c 'GRANT ALL privileges ON DATABASE librephotos TO librephotos;'

--- a/ressources/etc/librephotos/librephotos-backend.env
+++ b/ressources/etc/librephotos/librephotos-backend.env
@@ -6,21 +6,13 @@ BACKEND_HOST=localhost
 FORWARDED_ALLOW_IPS=
 
 DB_BACKEND=postgresql
-DB_HOST=localhost
-DB_PORT=5432
+DB_HOST=
+DB_PORT=
 DB_NAME=librephotos
 DB_USER=librephotos
 DB_PASS=password
 
-REDIS_PASS=
-#redis local ou redis distant
-#REDIS_PATH=
-#REDIS_DB=
-# redis distant
-REDIS_HOST=localhost
-REDIS_PORT=6379
 
-TIME_ZONE=Europe/Berlin
 SECRET_KEY=SecretKeyToBeDefined
 MAPBOX_API_KEY=
 DEBUG=0

--- a/ressources/etc/nginx/librephotos
+++ b/ressources/etc/nginx/librephotos
@@ -23,6 +23,10 @@ add_header X-Robots-Tag                         "none"          always;
 add_header X-XSS-Protection                     "1; mode=block" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload;";
 
+access_log /var/log/nginx/librephotos.access;
+error_log /var/log/nginx/librephotos.error warn;
+
+
 # Remove X-Powered-By, which is an information leak
 fastcgi_hide_header X-Powered-By;
 add_header Permissions-Policy                   "geolocation=(self)" always;
@@ -47,16 +51,19 @@ add_header Permissions-Policy                   "geolocation=(self)" always;
     # Django media
     location /protected_media  {
         internal;
+        # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/protected_media/;
     }
     # Original Photos
     location /original  {
         internal;
+        # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/data/;
     }
     # Nextcloud Original Photos
     location /nextcloud_original  {
         internal;
+        # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/data/nextcloud_media/;
     }
 

--- a/ressources/etc/nginx/librephotos
+++ b/ressources/etc/nginx/librephotos
@@ -54,6 +54,13 @@ add_header Permissions-Policy                   "geolocation=(self)" always;
         # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/protected_media/;
     }
+
+    location /data  {
+        internal;
+        # The begining of the path must be same like in the installation script BASE_DATA
+        alias /var/lib/librephotos/data/;
+    }
+
     # Original Photos
     location /original  {
         internal;

--- a/ressources/etc/nginx/nginx.conf
+++ b/ressources/etc/nginx/nginx.conf
@@ -30,6 +30,13 @@ http {
         # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/protected_media/;
     }
+        
+    location /data  {
+        internal;
+        alias /var/lib/librephotos/data/;
+    }
+
+
     # Original Photos
     location /original  {
         internal;

--- a/ressources/etc/nginx/nginx.conf
+++ b/ressources/etc/nginx/nginx.conf
@@ -27,16 +27,19 @@ http {
     # Django media
     location /protected_media  {
         internal;
+        # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/protected_media/;
     }
     # Original Photos
     location /original  {
         internal;
+        # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/data/;
     }
     # Nextcloud Original Photos
     location /nextcloud_original  {
         internal;
+        # The begining of the path must be same like in the installation script BASE_DATA
         alias /var/lib/librephotos/data/nextcloud_media/;
     }
   }

--- a/ressources/systemd/librephotos-backend.service
+++ b/ressources/systemd/librephotos-backend.service
@@ -2,12 +2,12 @@
 Description=librephotos-backend
 Documentation=https://github.com/LibrePhotos/librephotos
 
-#Default case
-After=network.target
+# case when PostgreSQL is on remote host
+#After=network.target
 
 # case when PostgreSQL is on localhost
-# After=network.target postgresql.service
-# Requires=postgresql.service
+After=network.target postgresql.service
+Requires=postgresql.service
 
 [Service]
 User=librephotos

--- a/ressources/systemd/librephotos-worker.service
+++ b/ressources/systemd/librephotos-worker.service
@@ -2,11 +2,12 @@
 Description=librephotos-worker
 Documentation=https://github.com/LibrePhotos/librephotos
 
+# case when PostgreSQL is on localhost
 After=network.target
 
 # case when PostgreSQL is on localhost
-# After=network.target postgresql.service
-# Requires=postgresql.service
+After=network.target postgresql.service
+Requires=postgresql.service
 
 [Service]
 User=librephotos

--- a/ressources/systemd/librephotos-worker.service
+++ b/ressources/systemd/librephotos-worker.service
@@ -3,7 +3,7 @@ Description=librephotos-worker
 Documentation=https://github.com/LibrePhotos/librephotos
 
 # case when PostgreSQL is on localhost
-After=network.target
+# After=network.target
 
 # case when PostgreSQL is on localhost
 After=network.target postgresql.service


### PR DESCRIPTION
Closes:
#13 nginx
#25 home direcotory
#26 skip compilation. PARTIALLY. Check libvips exsitense, and compiles only if linux command "vips" no found. Todo: check places365, im2txt and resnet152-b121ed2d.pth, dlib.
#30 cleanup script. Added info what to clean and ''semi script' - copy - paste to terminal to clean almost all.
#31 debian and ubuntu differences
#32 no module pyvips. Must be removed older libvips and compiled new libvips (current 8.12.1). Version mismatch between system vips and pyvips kills gunicorn. Reasons know, but in the script does not cleans system. 
#33 clip-embeddings

Other: if REDIS already present on the system, and connection through SOCKET, installation fails. Also added REDIS connection settings to the begin of the script.