### PR TITLE
keep container running after all processes are started

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,4 +12,5 @@ systemctl start postgresql.service
 systemctl enable postgresql.service
 /usr/lib/librephotos/bin/librephotos-upgrade
 systemctl restart nginx
-watch systemctl status librephotos-backend
+# keep container running
+while true; do sleep 1; done


### PR DESCRIPTION
Add infinite loop as the last command to the docker container so it's not terminating when all services are started.
Watch command was failing because it needs TTY which is not available when running headless.